### PR TITLE
Fix out of Omaha landlords data to not include properties outside omaha.

### DIFF
--- a/src/parcel-parser.js
+++ b/src/parcel-parser.js
@@ -22,8 +22,15 @@ const includeInLowCondition = (parcel) => {
     return hasLowCondition && notOwnersProperty;
 }
 
+const includeInOutOfOmaha = (parcel) => {
+    const ownerOutsideOmaha = parcel.OWNER_CITY.toUpperCase() !== "OMAHA";
+    const ownerFromNebraska = parcel.OWNER_STAT.toUpperCase() === "NE";
+    const propertyInsideOmaha = parcel.PROP_CITY.toUpperCase() === "OMAHA";
+    return ownerOutsideOmaha && ownerFromNebraska && propertyInsideOmaha;
+}
+
 parcels.forEach((parcel) => {
-    if(includeInLowCondition(parcel)){
+    if(includeInOutOfOmaha(parcel)){
         data.push(parcel);
     }
 })


### PR DESCRIPTION
This issue was showing, for example, landlords that live in Bennington and own property in Bennington.